### PR TITLE
Upgrade dependencies to resolve audit problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
         "eslint-plugin-node":     "11.1.0"
     },
     "dependencies": {
-        "get-stream":             "6.0.1",
+        "get-stream":             "9.0.1",
         "js-yaml":                "4.1.0",
-        "strip-ansi":             "6.0.0",
-        "got":                    "11.8.6",
-        "webdav":                 "4.11.2",
-        "chalk":                  "4.1.2",
+        "strip-ansi":             "7.1.0",
+        "got":                    "14.4.3",
+        "webdav":                 "5.7.1",
+        "chalk":                  "5.3.0",
         "dayjs":                  "1.11.13"
     },
     "upd":                        [ "!strip-ansi", "!chalk", "!got", "!webdav" ],


### PR DESCRIPTION
Upgraded dependencies to resolve audit problems:
```
axios  0.8.1 - 0.27.2
Severity: moderate
Axios Cross-Site Request Forgery Vulnerability - https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
fix available via `npm audit fix --force`
Will install json-asty@1.1.1, which is a breaking change
node_modules/webdav/node_modules/axios
  webdav  2.0.0-rc1 - 5.1.0
  Depends on vulnerable versions of axios
  Depends on vulnerable versions of fast-xml-parser
  node_modules/webdav
    cli-io  *
    Depends on vulnerable versions of webdav
    node_modules/cli-io

fast-xml-parser  <=4.4.0
Severity: high
fast-xml-parser vulnerable to Prototype Pollution through tag or attribute name - https://github.com/advisories/GHSA-x3cc-x39p-42qx
fast-xml-parser vulnerable to ReDOS at currency parsing - https://github.com/advisories/GHSA-mpg4-rc92-vx8v
fix available via `npm audit fix --force`
Will install json-asty@1.1.1, which is a breaking change
node_modules/fast-xml-parser
```